### PR TITLE
Fix custom mask in extras

### DIFF
--- a/scripts/nudenet_nsfw_censor_scripts/post_processing_script.py
+++ b/scripts/nudenet_nsfw_censor_scripts/post_processing_script.py
@@ -167,7 +167,7 @@ class ScriptPostprocessingNudenetCensor(scripts_postprocessing.ScriptPostprocess
 
             if nudenet_mask and censor_mask:
                 censor_mask.paste(nudenet_mask, nudenet_mask)
-            else:
+            elif not censor_mask:
                 censor_mask = nudenet_mask
 
         if censor_mask:


### PR DESCRIPTION
Fix custom mask in extras, if nudenet autodetect is enabled, but nothing has been detected
It  doesn't work because `nudenet_mask` is None, but `censor_mask` is not None. But in else branch None is written in `censor_mask`

Sorry for 1-line PR