### PR TITLE
Forge extra tab compatibility fix 3

### DIFF
--- a/scripts/nudenet_nsfw_censor_scripts/pil_nude_detector.py
+++ b/scripts/nudenet_nsfw_censor_scripts/pil_nude_detector.py
@@ -4,6 +4,7 @@ from cv2.dnn import NMSBoxes
 from modules import shared
 from pathlib import Path
 from math import sqrt
+from tqdm import tqdm
 import numpy as np
 
 nudenet_labels_dict = {
@@ -163,7 +164,7 @@ class PilNudeDetector:
             else:
                 image_mask = Image.new('1', img_size, 0)
                 draw = ImageDraw.Draw(image_mask)
-                verbose = ''
+                verbose = []
 
                 max_score_indices = np.argmax(outputs[:, 4:], axis=1)
                 detection_results = outputs[filter_results]
@@ -199,18 +200,17 @@ class PilNudeDetector:
                 boxes[:, 2:4] = boxes[:, 0:2] + wh_e
                 boxes = boxes.round()
 
+                nudenet_nsfw_censor_verbose_detection = shared.opts.nudenet_nsfw_censor_verbose_detection
                 for i in range(scores.shape[0]):
                     x1y1x2y2 = boxes[i]
                     wh = wh_e[i]
                     draw_func(draw, *x1y1x2y2, *wh, rectangle_round_radius)
 
-                    if shared.opts.nudenet_nsfw_censor_verbose_detection:
-                        verbose += (
-                            f'\n{nudenet_labels_friendly_name[class_index[i]]}: score {scores[i]}, x1 {x1y1x2y2[0]} y1 {x1y1x2y2[1]}, w {wh[0].round()} h {wh[1].round()}, x2 {x1y1x2y2[2]} y2 {x1y1x2y2[3]}'
-                        )
+                    if nudenet_nsfw_censor_verbose_detection:
+                        verbose.append(f'{nudenet_labels_friendly_name[class_index[i]]}: score {scores[i]}, x1 {x1y1x2y2[0]} y1 {x1y1x2y2[1]}, w {wh[0].round()} h {wh[1].round()}, x2 {x1y1x2y2[2]} y2 {x1y1x2y2[3]}')
 
                 if verbose:
-                    print(verbose)
+                    tqdm.write('\n' + '\n'.join(verbose))
 
                 return image_mask
 

--- a/scripts/nudenet_nsfw_censor_scripts/pil_nude_detector.py
+++ b/scripts/nudenet_nsfw_censor_scripts/pil_nude_detector.py
@@ -214,6 +214,8 @@ class PilNudeDetector:
 
                 return image_mask
 
+        return None
+
     def get_censor_mask(self, pil_image, nms_threshold, nudenet_nsfw_censor_mask_shape, rectangle_round_radius, thresholds, expand_horizontal, expand_vertical):
         if self.onnx_session is None:
             self.init_onnx()

--- a/scripts/nudenet_nsfw_censor_scripts/post_processing_script.py
+++ b/scripts/nudenet_nsfw_censor_scripts/post_processing_script.py
@@ -67,114 +67,136 @@ class ScriptPostprocessingNudenetCensor(scripts_postprocessing.ScriptPostprocess
             else gr.Accordion('NSFW Censor', open=False, elem_id='nudenet_nsfw_censor_extras')
             as enable
         ):
-            with gr.Row():
-                if not InputAccordion:
-                    enable = gr.Checkbox(False, label='Enable', elem_id='nudenet_nsfw_censor_extras-visible-checkbox')
-                enable_nudenet = gr.Checkbox(True, label='NudeNet Auto-detect')
-                save_mask = gr.Checkbox(False, label='Save mask')
-                override_settings = gr.Checkbox(False, label='Override filter configs')
-            with gr.Row():
-                filter_type = gr.Dropdown(value='Variable blur', label='Censor filter', choices=list(filter_dict), visible=False)
-                mask_shape = gr.Dropdown(value='Ellipse', choices=list(mask_shapes_func_dict), label='Mask shape', visible=False)
-            with gr.Row():
-                blur_radius = gr.Slider(0, 100, 10, label='Blur radius', visible=False)  # Variable blur Gaussian Blur
-                blur_strength_curve = gr.Slider(0, 6, 3, label='Blur strength curve', visible=False)  # Variable blur
-                pixelation_factor = gr.Slider(1, 10, 5, label='Pixelation factor', visible=False)  # Pixelate
-                fill_color = gr.ColorPicker(value='#000000', label='fill color', visible=False)  # Fill color
-                mask_blend_radius = gr.Slider(0, 100, 0, label='Mask blend radius', visible=False)  # except Variable blur
-                mask_blend_radius_variable_blur = gr.Slider(0, 100, 10, label='Variable blur mask blend radius', visible=False)  # Variable blur
-                nms_threshold = gr.Slider(0, 1, 1, label='NMS threshold', visible=False)  # NMS threshold
-                rectangle_round_radius = gr.Number(value=0.5, label='Rectangle round radius', visible=False)  # Rounded rectangle
+            with gr.Blocks(analytics_enabled=False) as block:
+                with gr.Row() as row_0:
+                    if not InputAccordion:
+                        enable = gr.Checkbox(False, label='Enable', elem_id='nudenet_nsfw_censor_extras-visible-checkbox')
+                    enable_nudenet = gr.Checkbox(True, label='NudeNet Auto-detect')
+                    save_mask = gr.Checkbox(False, label='Save mask')
+                    override_settings = gr.Checkbox(False, label='Override filter configs')
+                with gr.Row() as row_1:
+                    filter_type = gr.Dropdown(value='Variable blur', label='Censor filter', choices=list(filter_dict), visible=False)
+                    mask_shape = gr.Dropdown(value='Ellipse', choices=list(mask_shapes_func_dict), label='Mask shape', visible=False)
+                with gr.Row() as row_2:
+                    blur_radius = gr.Slider(0, 100, 10, label='Blur radius', visible=False)  # Variable blur Gaussian Blur
+                    blur_strength_curve = gr.Slider(0, 6, 3, label='Blur strength curve', visible=False)  # Variable blur
+                    pixelation_factor = gr.Slider(1, 10, 5, label='Pixelation factor', visible=False)  # Pixelate
+                    fill_color = gr.ColorPicker(value='#000000', label='fill color', visible=False)  # Fill color
+                    mask_blend_radius = gr.Slider(0, 100, 0, label='Mask blend radius', visible=False)  # except Variable blur
+                    mask_blend_radius_variable_blur = gr.Slider(0, 100, 10, label='Variable blur mask blend radius', visible=False)  # Variable blur
+                    nms_threshold = gr.Slider(0, 1, 1, label='NMS threshold', visible=False)  # NMS threshold
+                    rectangle_round_radius = gr.Number(value=0.5, label='Rectangle round radius', visible=False)  # Rounded rectangle
 
-            if not forge or forge_no_error:
-                with gr.Row():
-                    if not forge or extra_src_image:
-                        create_canvas = gr.Button('Create canvas')
-                    if forge:
-                        with gr.Column():
-                            draw_mask = gr.Checkbox(True, label='Draw mask', elem_id="nsfw_censor_forge_draw mask", )
-                            upload_mask = gr.Checkbox(False, label='Upload mask', elem_id="nsfw_censor_forge_upload_mask")
-                    else:
-                        mask_source = gr.CheckboxGroup(['Draw mask', 'Upload mask'], value=['Draw mask'], label="Canvas mask source")
-                        mask_brush_color = gr.ColorPicker('#000000', label='Brush color', info='visual only, use when brush color is hard to see')
-                with gr.Row():
-                    if forge:
-                        if forge_no_error:
-                            forge_canvas = ForgeCanvas(
-                                elem_id="nsfw_censor_mask",
-                                height=512,
-                                contrast_scribbles=shared.opts.img2img_inpaint_mask_high_contrast,
-                                scribble_color=shared.opts.img2img_inpaint_mask_brush_color,
-                                scribble_color_fixed=True,
-                                scribble_alpha=shared.opts.img2img_inpaint_mask_scribble_alpha,
-                                scribble_alpha_fixed=True,
-                                scribble_softness_fixed=True,
-                            )
-
-                            if extra_src_image:
-                                def get_current_image(image):
-                                    return image, None
-
-                                create_canvas.click(
-                                    fn=get_current_image,
-                                    inputs=[extra_src_image],
-                                    outputs=[forge_canvas.background, forge_canvas.foreground],
+                if not forge or forge_no_error:
+                    with gr.Row():
+                        if not forge or extra_src_image:
+                            create_canvas = gr.Button('Create canvas')
+                        if forge:
+                            with gr.Column():
+                                draw_mask = gr.Checkbox(True, label='Draw mask', elem_id="nsfw_censor_forge_draw mask", )
+                                upload_mask = gr.Checkbox(False, label='Upload mask', elem_id="nsfw_censor_forge_upload_mask")
+                        else:
+                            mask_source = gr.CheckboxGroup(['Draw mask', 'Upload mask'], value=['Draw mask'], label="Canvas mask source")
+                            mask_brush_color = gr.ColorPicker('#000000', label='Brush color', info='visual only, use when brush color is hard to see')
+                    with gr.Row():
+                        if forge:
+                            if forge_no_error:
+                                forge_canvas = ForgeCanvas(
+                                    elem_id="nsfw_censor_mask",
+                                    height=512,
+                                    contrast_scribbles=shared.opts.img2img_inpaint_mask_high_contrast,
+                                    scribble_color=shared.opts.img2img_inpaint_mask_brush_color,
+                                    scribble_color_fixed=True,
+                                    scribble_alpha=shared.opts.img2img_inpaint_mask_scribble_alpha,
+                                    scribble_alpha_fixed=True,
+                                    scribble_softness_fixed=True,
                                 )
 
-                    else:
-                        input_mask = gr.Image(
-                            label="Censor mask",
-                            show_label=False,
-                            elem_id="nsfw_censor_mask",
-                            source="upload",
-                            interactive=True,
-                            type="pil",
-                            tool="sketch",
-                            image_mode="RGBA",
-                            brush_color='#000000'
-                        )
+                                if extra_src_image:
+                                    def get_current_image(image):
+                                        return image, None
 
-                        def update_mask_brush_color(color):
-                            return gr.Image.update(brush_color=color)
+                                    create_canvas.click(
+                                        fn=get_current_image,
+                                        inputs=[extra_src_image],
+                                        outputs=[forge_canvas.background, forge_canvas.foreground],
+                                    )
 
-                        mask_brush_color.change(
-                            fn=update_mask_brush_color,
-                            inputs=[mask_brush_color],
-                            outputs=[input_mask]
-                        )
+                        else:
+                            input_mask = gr.Image(
+                                label="Censor mask",
+                                show_label=False,
+                                elem_id="nsfw_censor_mask",
+                                source="upload",
+                                interactive=True,
+                                type="pil",
+                                tool="sketch",
+                                image_mode="RGBA",
+                                brush_color='#000000'
+                            )
 
-                        def get_current_image(image):
-                            # ToDo if possible make this a client side operation
-                            return gr.Image.update(image) if image else None
+                            def update_mask_brush_color(color):
+                                return gr.Image.update(brush_color=color)
 
-                        dummy_component = gr.Label(visible=False)
-                        create_canvas.click(
-                            fn=get_current_image,
-                            _js='getCurrentExtraSourceImg',
-                            inputs=[dummy_component],
-                            outputs=[input_mask],
-                            postprocess=False,
-                        )
+                            mask_brush_color.change(
+                                fn=update_mask_brush_color,
+                                inputs=[mask_brush_color],
+                                outputs=[input_mask]
+                            )
 
-            def update_opt_ui(_filter_type, _mask_shape, _override_settings, _enable_nudenet):
-                filter_opt_enable_list = filter_opt_ui_show_dict[_filter_type]
-                mask_shape_opt_show_list = mask_shape_opt_ui_show_dict[_mask_shape]
-                # blur_radius, blur_strength_curve, pixelation_factor, fill_color, mask_blend_radius, mask_blend_radius_variable_blur, rectangle_round_radius, nms_threshold
-                return (
-                    gr.Dropdown.update(visible=_override_settings),  # filter_type
-                    gr.Dropdown.update(visible=_override_settings),  # mask_shape
-                    gr.Slider.update(visible=_override_settings and filter_opt_enable_list[0]),  # blur_radius
-                    gr.Slider.update(visible=_override_settings and filter_opt_enable_list[1]),  # blur_strength_curve
-                    gr.Slider.update(visible=_override_settings and filter_opt_enable_list[2]),  # pixelation_factor
-                    gr.ColorPicker.update(visible=_override_settings and filter_opt_enable_list[3]),  # fill_color
-                    gr.Slider.update(visible=_override_settings and filter_opt_enable_list[4] and mask_shape_opt_show_list[0]),  # mask_blend_radius
-                    gr.Slider.update(visible=_override_settings and filter_opt_enable_list[5] and mask_shape_opt_show_list[0]),  # mask_blend_radius_variable_blur
-                    gr.Number().update(visible=_override_settings and mask_shape_opt_show_list[1]),  # rectangle_round_radius
-                    gr.Slider.update(visible=_override_settings and mask_shape_opt_show_list[2] and _enable_nudenet),  # nms_threshold
-                )
+                            def get_current_image(image):
+                                # ToDo if possible make this a client side operation
+                                return gr.Image.update(image) if image else None
 
-            for element in [override_settings, filter_type, mask_shape, enable_nudenet]:
-                element.change(update_opt_ui, inputs=[filter_type, mask_shape, override_settings, enable_nudenet], outputs=[filter_type, mask_shape, blur_radius, blur_strength_curve, pixelation_factor, fill_color, mask_blend_radius, mask_blend_radius_variable_blur, rectangle_round_radius, nms_threshold])
+                            dummy_component = gr.Label(visible=False)
+                            create_canvas.click(
+                                fn=get_current_image,
+                                _js='getCurrentExtraSourceImg',
+                                inputs=[dummy_component],
+                                outputs=[input_mask],
+                                postprocess=False,
+                            )
+
+                def update_opt_ui(_filter_type, _mask_shape, _override_settings, _enable_nudenet):
+                    filter_opt_enable_list = filter_opt_ui_show_dict[_filter_type]
+                    mask_shape_opt_show_list = mask_shape_opt_ui_show_dict[_mask_shape]
+                    # blur_radius, blur_strength_curve, pixelation_factor, fill_color, mask_blend_radius, mask_blend_radius_variable_blur, rectangle_round_radius, nms_threshold, row_1, row_2
+                    return (
+                        gr.Dropdown.update(visible=_override_settings),  # filter_type
+                        gr.Dropdown.update(visible=_override_settings),  # mask_shape
+                        gr.Slider.update(visible=_override_settings and filter_opt_enable_list[0]),  # blur_radius
+                        gr.Slider.update(visible=_override_settings and filter_opt_enable_list[1]),  # blur_strength_curve
+                        gr.Slider.update(visible=_override_settings and filter_opt_enable_list[2]),  # pixelation_factor
+                        gr.ColorPicker.update(visible=_override_settings and filter_opt_enable_list[3]),  # fill_color
+                        gr.Slider.update(visible=_override_settings and filter_opt_enable_list[4] and mask_shape_opt_show_list[0]),  # mask_blend_radius
+                        gr.Slider.update(visible=_override_settings and filter_opt_enable_list[5] and mask_shape_opt_show_list[0]),  # mask_blend_radius_variable_blur
+                        gr.Number().update(visible=_override_settings and mask_shape_opt_show_list[1]),  # rectangle_round_radius
+                        gr.Slider.update(visible=_override_settings and mask_shape_opt_show_list[2] and _enable_nudenet),  # nms_threshold
+                        gr.Row.update(visible=_override_settings),  # row_1
+                        gr.Row.update(visible=_override_settings and any(mask_shape_opt_show_list)),  # row_2
+                    )
+
+                update_opt_ui_inputs = [
+                    filter_type,
+                    mask_shape,
+                    override_settings,
+                    enable_nudenet,
+                ]
+                update_opt_ui_outputs = [
+                    filter_type, mask_shape,
+                    blur_radius, blur_strength_curve,
+                    pixelation_factor, fill_color,
+                    mask_blend_radius,
+                    mask_blend_radius_variable_blur,
+                    rectangle_round_radius,
+                    nms_threshold,
+                    row_1,
+                    row_2,
+                ]
+
+                for element in [override_settings, filter_type, mask_shape, enable_nudenet]:
+                    element.change(update_opt_ui, inputs=update_opt_ui_inputs, outputs=update_opt_ui_outputs, show_progress=False)
+                block.load(update_opt_ui, inputs=update_opt_ui_inputs, outputs=update_opt_ui_outputs, show_progress=False)
 
         controls = {
             'enable': enable,

--- a/scripts/nudenet_nsfw_censor_scripts/post_processing_script.py
+++ b/scripts/nudenet_nsfw_censor_scripts/post_processing_script.py
@@ -48,12 +48,15 @@ filter_opt_ui_show_dict = {
     'Fill color': [False, False, False, True, True, False],
     'No censor': [False, False, False, False, True, False],
 }
+
+entire_image_always = 'Entire image (always)'
 mask_shape_opt_ui_show_dict = {
     # [(mask_blend_radius, mask_blend_radius_variable_blur), rectangle_round_radius, nms_threshold]
     'Ellipse': [True, False, True],
     'Rectangle': [True, False, True],
     'Rounded rectangle': [True, True, True],
-    'Entire image': [False, False, False]
+    'Entire image': [False, False, False],
+    entire_image_always: [False, False, False],
 }
 
 
@@ -75,8 +78,8 @@ class ScriptPostprocessingNudenetCensor(scripts_postprocessing.ScriptPostprocess
                     save_mask = gr.Checkbox(False, label='Save mask')
                     override_settings = gr.Checkbox(False, label='Override filter configs')
                 with gr.Row() as row_1:
-                    mask_shape = gr.Dropdown(value='Ellipse', choices=list(mask_shapes_func_dict), label='Mask shape', visible=False)
                     filter_type = gr.Dropdown(value='Variable blur', label='Censor filter', choices=list(filter_opt_ui_show_dict), visible=False)
+                    mask_shape = gr.Dropdown(value='Ellipse', choices=list(mask_shapes_func_dict) + [entire_image_always], label='Mask shape', visible=False)
                 with gr.Row() as row_2:
                     blur_radius = gr.Slider(0, 100, 10, label='Blur radius', visible=False)  # Variable blur Gaussian Blur
                     blur_strength_curve = gr.Slider(0, 6, 3, label='Blur strength curve', visible=False)  # Variable blur
@@ -160,7 +163,7 @@ class ScriptPostprocessingNudenetCensor(scripts_postprocessing.ScriptPostprocess
                 def update_opt_ui(_filter_type, _mask_shape, _override_settings, _enable_nudenet):
                     filter_opt_enable_list = filter_opt_ui_show_dict[_filter_type]
                     mask_shape_opt_show_list = mask_shape_opt_ui_show_dict[_mask_shape]
-                    # blur_radius, blur_strength_curve, pixelation_factor, fill_color, mask_blend_radius, mask_blend_radius_variable_blur, rectangle_round_radius, nms_threshold, row_1, row_2
+
                     return (
                         gr.Dropdown.update(visible=_override_settings),  # filter_type
                         gr.Dropdown.update(visible=_override_settings),  # mask_shape
@@ -170,10 +173,10 @@ class ScriptPostprocessingNudenetCensor(scripts_postprocessing.ScriptPostprocess
                         gr.ColorPicker.update(visible=_override_settings and filter_opt_enable_list[3]),  # fill_color
                         gr.Slider.update(visible=_override_settings and filter_opt_enable_list[4] and mask_shape_opt_show_list[0]),  # mask_blend_radius
                         gr.Slider.update(visible=_override_settings and filter_opt_enable_list[5] and mask_shape_opt_show_list[0]),  # mask_blend_radius_variable_blur
-                        gr.Number().update(visible=_override_settings and mask_shape_opt_show_list[1]),  # rectangle_round_radius
-                        gr.Slider.update(visible=_override_settings and mask_shape_opt_show_list[2] and _enable_nudenet),  # nms_threshold
+                        gr.Number().update(visible=_override_settings and _enable_nudenet and mask_shape_opt_show_list[1]),  # rectangle_round_radius
+                        gr.Slider.update(visible=_override_settings and _enable_nudenet and mask_shape_opt_show_list[2]),  # nms_threshold
                         gr.Row.update(visible=_override_settings),  # row_1
-                        gr.Row.update(visible=_override_settings and any(mask_shape_opt_show_list)),  # row_2
+                        gr.Row.update(visible=_override_settings or any(mask_shape_opt_show_list)),  # row_2
                     )
 
                 update_opt_ui_inputs = [
@@ -234,47 +237,50 @@ class ScriptPostprocessingNudenetCensor(scripts_postprocessing.ScriptPostprocess
             return
         censor_mask = None
 
-        if forge:
-            forge_canvas_bg = args.get('forge_canvas_bg')
-            forge_canvas_fg = args.get('forge_canvas_fg')
-            if args.get('upload_mask') and forge_canvas_bg:
-                censor_mask = forge_canvas_bg.convert('L').resize(pp.image.size)
-            if args.get('draw_mask') and forge_canvas_fg:
-                censor_mask = Image.new('L', pp.image.size, 0) if censor_mask is None else censor_mask
-                r, g, b, a = forge_canvas_fg.split()
-                draw_mask = a.convert('L').resize(pp.image.size)
-                censor_mask.paste(draw_mask, draw_mask)
+        if args['mask_shape'] == entire_image_always:
+            censor_mask = Image.new('L', pp.image.size, 255)
         else:
-            input_mask = args.get('input_mask')
-            if input_mask:
-                mask_source = args.get('mask_source')
-                if 'Upload mask' in mask_source:
-                    censor_mask = input_mask['image'].convert('L').resize(pp.image.size)
-                if 'Draw mask' in mask_source:
+            if forge:
+                forge_canvas_bg = args.get('forge_canvas_bg')
+                forge_canvas_fg = args.get('forge_canvas_fg')
+                if args.get('upload_mask') and forge_canvas_bg:
+                    censor_mask = forge_canvas_bg.convert('L').resize(pp.image.size)
+                if args.get('draw_mask') and forge_canvas_fg:
                     censor_mask = Image.new('L', pp.image.size, 0) if censor_mask is None else censor_mask
-                    draw_mask = input_mask['mask'].convert('L').resize(pp.image.size)
+                    r, g, b, a = forge_canvas_fg.split()
+                    draw_mask = a.convert('L').resize(pp.image.size)
                     censor_mask.paste(draw_mask, draw_mask)
-
-        if args['enable_nudenet']:
-            if args['override_settings']:
-                nms_threshold = args['nms_threshold']
-                mask_shape = args['mask_shape']
-                rectangle_round_radius = args['rectangle_round_radius']
             else:
-                nms_threshold = shared.opts.nudenet_nsfw_censor_nms_threshold
-                mask_shape = shared.opts.nudenet_nsfw_censor_mask_shape
-                rectangle_round_radius = shared.opts.nudenet_nsfw_censor_rectangle_round_radius
+                input_mask = args.get('input_mask')
+                if input_mask:
+                    mask_source = args.get('mask_source')
+                    if 'Upload mask' in mask_source:
+                        censor_mask = input_mask['image'].convert('L').resize(pp.image.size)
+                    if 'Draw mask' in mask_source:
+                        censor_mask = Image.new('L', pp.image.size, 0) if censor_mask is None else censor_mask
+                        draw_mask = input_mask['mask'].convert('L').resize(pp.image.size)
+                        censor_mask.paste(draw_mask, draw_mask)
 
-            if pil_nude_detector.thresholds is None:
-                pil_nude_detector.refresh_label_configs()
-            nudenet_mask = pil_nude_detector.get_censor_mask(pp.image, nms_threshold, mask_shape, rectangle_round_radius, pil_nude_detector.thresholds, pil_nude_detector.expand_horizontal, pil_nude_detector.expand_vertical)
-            if nudenet_mask is not None:
-                nudenet_mask = nudenet_mask.convert('L')
+            if args['enable_nudenet']:
+                if args['override_settings']:
+                    nms_threshold = args['nms_threshold']
+                    mask_shape = args['mask_shape']
+                    rectangle_round_radius = args['rectangle_round_radius']
+                else:
+                    nms_threshold = shared.opts.nudenet_nsfw_censor_nms_threshold
+                    mask_shape = shared.opts.nudenet_nsfw_censor_mask_shape
+                    rectangle_round_radius = shared.opts.nudenet_nsfw_censor_rectangle_round_radius
 
-            if nudenet_mask and censor_mask:
-                censor_mask.paste(nudenet_mask, nudenet_mask)
-            elif not censor_mask:
-                censor_mask = nudenet_mask
+                if pil_nude_detector.thresholds is None:
+                    pil_nude_detector.refresh_label_configs()
+                nudenet_mask = pil_nude_detector.get_censor_mask(pp.image, nms_threshold, mask_shape, rectangle_round_radius, pil_nude_detector.thresholds, pil_nude_detector.expand_horizontal, pil_nude_detector.expand_vertical)
+                if nudenet_mask is not None:
+                    nudenet_mask = nudenet_mask.convert('L')
+
+                if nudenet_mask and censor_mask:
+                    censor_mask.paste(nudenet_mask, nudenet_mask)
+                elif not censor_mask:
+                    censor_mask = nudenet_mask
 
         if censor_mask:
 

--- a/scripts/nudenet_nsfw_censor_scripts/post_processing_script.py
+++ b/scripts/nudenet_nsfw_censor_scripts/post_processing_script.py
@@ -19,16 +19,16 @@ extra_src_image = None
 try:
     if find_spec('modules_forge'):
         forge = True
-    from modules_forge.forge_canvas.canvas import ForgeCanvas
-    from modules.script_callbacks import on_after_component
+        from modules_forge.forge_canvas.canvas import ForgeCanvas
+        from modules.script_callbacks import on_after_component
 
-    def get_extra_img_elem(component, **_kwargs):
-        global extra_src_image
-        if getattr(component, "elem_id", None) == "extras_image":
-            extra_src_image = component
+        def get_extra_img_elem(component, **_kwargs):
+            global extra_src_image
+            if getattr(component, "elem_id", None) == "extras_image":
+                extra_src_image = component
 
-    on_after_component(get_extra_img_elem)
-    forge_no_error = True
+        on_after_component(get_extra_img_elem)
+        forge_no_error = True
 except Exception as e:
     errors.report(
         '''Error loading sd-webui-nudenet-nsfw-censor extras tab on Forge

--- a/scripts/nudenet_nsfw_censor_scripts/post_processing_script.py
+++ b/scripts/nudenet_nsfw_censor_scripts/post_processing_script.py
@@ -1,5 +1,5 @@
 from scripts.nudenet_nsfw_censor_scripts.pil_nude_detector import pil_nude_detector, mask_shapes_func_dict
-from scripts.nudenet_nsfw_censor_scripts.censor_image_filters import apply_filter, filter_dict
+from scripts.nudenet_nsfw_censor_scripts.censor_image_filters import apply_filter
 from modules import shared, images, scripts_postprocessing, errors
 from importlib.util import find_spec
 from PIL import Image, ImageFilter
@@ -46,7 +46,7 @@ filter_opt_ui_show_dict = {
     'Gaussian Blur': [True, False, False, False, True, False],
     'Pixelate': [False, False, True, False, True, False],
     'Fill color': [False, False, False, True, True, False],
-    'Detect only': [False, False, False, False, True, False],
+    'No censor': [False, False, False, False, True, False],
 }
 mask_shape_opt_ui_show_dict = {
     # [(mask_blend_radius, mask_blend_radius_variable_blur), rectangle_round_radius, nms_threshold]
@@ -75,8 +75,8 @@ class ScriptPostprocessingNudenetCensor(scripts_postprocessing.ScriptPostprocess
                     save_mask = gr.Checkbox(False, label='Save mask')
                     override_settings = gr.Checkbox(False, label='Override filter configs')
                 with gr.Row() as row_1:
-                    filter_type = gr.Dropdown(value='Variable blur', label='Censor filter', choices=list(filter_dict), visible=False)
                     mask_shape = gr.Dropdown(value='Ellipse', choices=list(mask_shapes_func_dict), label='Mask shape', visible=False)
+                    filter_type = gr.Dropdown(value='Variable blur', label='Censor filter', choices=list(filter_opt_ui_show_dict), visible=False)
                 with gr.Row() as row_2:
                     blur_radius = gr.Slider(0, 100, 10, label='Blur radius', visible=False)  # Variable blur Gaussian Blur
                     blur_strength_curve = gr.Slider(0, 6, 3, label='Blur strength curve', visible=False)  # Variable blur


### PR DESCRIPTION
TL;DR
this time should fully address forge compatibility across multiple versions of forge

- again continuation of
- https://github.com/w-e-w/sd-webui-nudenet-nsfw-censor/pull/25
- https://github.com/w-e-w/sd-webui-nudenet-nsfw-censor/pull/26

hopefully this time we should fully address
- https://github.com/w-e-w/sd-webui-nudenet-nsfw-censor/issues/24

previously in #26 I was I was working with the assumption that people are using reasonably updated version of Forge
which sadly was not the case

in #26 I did not consider
1. old version of before [Forge Gradio 4 + WebUI 1.10 e26abf8 - 20240727](https://github.com/lllyasviel/stable-diffusion-webui-forge/commit/e26abf87ecd1eefd9ab0a198eee56f9c643e4001) which is the point that `ForgeCanvas` was introduced
2. for forge version after e26abf8 but before [couple of UI tweaks 21c907e](https://github.com/lllyasviel/stable-diffusion-webui-forge/commit/21c907ef87a662fc317866aa48772e24c8304fc7 - 20250206) whitch switch `extras_image` from `ForgeCanvas` back to `gr.Image`

originally before #25 as far as I am where this extension actually completely works on version prior to `Forge Gradio 4 + WebUI 1.10`
so what #25 did was "disables working features"

in #26 was a full fix for forge versions after `couple of UI tweaks`, but inadvertently break it for versions before `Forge Gradio 4 + WebUI 1.10`

this PR should make it so that it should work on most if not all versions of Forge
both also detection and manual masking via canvas is restored
but for version between `Forge Gradio 4 + WebUI 1.10` and `couple of UI tweaks` the convenient button not copies the input image to the masking canvas is disabled as it faces complications

---

### additional changes
- some minor UI tweaks hidding unnecessary roles when possible
- on `extras tab` add mask shape `Entire image (always)`
- - used for applying the filter to the entire image regardless of the input image
- - - the existing `Entire image` only works when auto detect something
- - - when this option is selected this extension in all access tab essentially turns into a blure / pixelation filter
- - - - might be useful for someone not sure

